### PR TITLE
feat: implement Vitest setup with hybrid approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,22 @@
 		"format": "turbo run format",
 		"lint": "turbo run lint",
 		"check": "turbo run check --continue",
-		"check-types": "turbo run check-types"
+		"check-types": "turbo run check-types",
+		"test": "turbo run test",
+		"test:watch": "turbo run test:watch",
+		"test:projects": "vitest run",
+		"test:projects:watch": "vitest --watch",
+		"test:coverage": "bun run test && bun run merge-coverage",
+		"merge-coverage": "node scripts/merge-coverage.js"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.1.1",
 		"lefthook": "^1.12.1",
+		"nyc": "latest",
 		"prettier": "^3.6.2",
 		"turbo": "^2.5.4",
-		"typescript": "5.8.3"
+		"typescript": "5.8.3",
+		"vitest": "latest"
 	},
 	"engines": {
 		"node": ">=18"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,14 +13,21 @@
 		"lint:fix": "biome lint --write .",
 		"check": "biome check --write . && bun run format:prettier",
 		"generate:component": "turbo gen react-component",
-		"check-types": "tsc --noEmit"
+		"check-types": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest --watch"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",
+		"@repo/vitest-config": "workspace:*",
 		"@types/node": "^22.15.3",
 		"@types/react": "19.1.0",
 		"@types/react-dom": "19.1.1",
-		"typescript": "5.8.2"
+		"@testing-library/react": "latest",
+		"@testing-library/jest-dom": "latest",
+		"jsdom": "latest",
+		"typescript": "5.8.2",
+		"vitest": "latest"
 	},
 	"dependencies": {
 		"react": "^19.1.0",

--- a/packages/ui/src/button.test.tsx
+++ b/packages/ui/src/button.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./button";
+
+// Mock window.alert
+Object.defineProperty(window, "alert", {
+	value: vi.fn(),
+	writable: true,
+});
+
+describe("Button", () => {
+	it("renders children correctly", () => {
+		render(<Button appName="test">Click me</Button>);
+		expect(screen.getByText("Click me")).toBeInTheDocument();
+	});
+
+	it("applies className correctly", () => {
+		render(
+			<Button appName="test" className="custom-class">
+				Click me
+			</Button>,
+		);
+		const button = screen.getByText("Click me");
+		expect(button).toHaveClass("custom-class");
+	});
+
+	it("shows alert with correct app name when clicked", () => {
+		const mockAlert = vi.fn();
+		window.alert = mockAlert;
+
+		render(<Button appName="test-app">Click me</Button>);
+		const button = screen.getByText("Click me");
+
+		fireEvent.click(button);
+
+		expect(mockAlert).toHaveBeenCalledWith("Hello from your test-app app!");
+	});
+});

--- a/packages/ui/src/test/setup.ts
+++ b/packages/ui/src/test/setup.ts
@@ -1,0 +1,4 @@
+import "@testing-library/jest-dom";
+
+// Global test setup goes here
+// Configure testing environment, mocks, etc.

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import { sharedConfig } from "@repo/vitest-config";
+
+export default defineConfig({
+	...sharedConfig,
+	test: {
+		...sharedConfig.test,
+		// Package-specific overrides if needed
+		coverage: {
+			...sharedConfig.test.coverage,
+			reportsDirectory: "./coverage",
+		},
+	},
+});

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@repo/vitest-config",
+	"version": "0.0.0",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"vitest": "latest"
+	},
+	"devDependencies": {
+		"@repo/typescript-config": "workspace:*",
+		"typescript": "latest"
+	}
+}

--- a/packages/vitest-config/src/index.ts
+++ b/packages/vitest-config/src/index.ts
@@ -1,0 +1,11 @@
+export const sharedConfig = {
+	test: {
+		globals: true,
+		environment: "jsdom",
+		setupFiles: ["./src/test/setup.ts"],
+		coverage: {
+			reporter: ["json", "html"],
+			reportsDirectory: "./coverage",
+		},
+	},
+};

--- a/packages/vitest-config/tsconfig.json
+++ b/packages/vitest-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@repo/typescript-config/base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["dist", "node_modules"]
+}

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Create coverage directory structure
+const coverageDir = path.join(__dirname, "../coverage");
+const mergedDir = path.join(coverageDir, "merged");
+const reportDir = path.join(coverageDir, "report");
+
+// Ensure directories exist
+if (!fs.existsSync(mergedDir)) {
+	fs.mkdirSync(mergedDir, { recursive: true });
+}
+if (!fs.existsSync(reportDir)) {
+	fs.mkdirSync(reportDir, { recursive: true });
+}
+
+try {
+	// Find all coverage.json files
+	const coverageFiles = [];
+	const searchForCoverageFiles = (dir) => {
+		const files = fs.readdirSync(dir);
+		files.forEach((file) => {
+			const filePath = path.join(dir, file);
+			const stat = fs.statSync(filePath);
+			if (stat.isDirectory()) {
+				searchForCoverageFiles(filePath);
+			} else if (file === "coverage.json") {
+				coverageFiles.push(filePath);
+			}
+		});
+	};
+
+	searchForCoverageFiles(path.join(__dirname, "../packages"));
+
+	if (coverageFiles.length === 0) {
+		console.log("No coverage files found.");
+		return;
+	}
+
+	console.log(`Found ${coverageFiles.length} coverage files:`);
+	coverageFiles.forEach((file) => console.log(`  - ${file}`));
+
+	// Merge coverage files
+	const mergedFile = path.join(mergedDir, "coverage.json");
+	execSync(`npx nyc merge ${coverageFiles.join(" ")} ${mergedFile}`);
+
+	// Generate report
+	execSync(`npx nyc report --reporter=html --reporter=text --report-dir=${reportDir} --temp-dir=${mergedDir}`);
+
+	console.log("Coverage reports merged successfully!");
+	console.log(`HTML report available at: ${path.join(reportDir, "index.html")}`);
+} catch (error) {
+	console.error("Error merging coverage reports:", error.message);
+	process.exit(1);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": [".next/**", "!.next/cache/**"]
+			"outputs": [".next/**", "!.next/cache/**", "dist/**"]
 		},
 		"format": {
 			"dependsOn": ["^format"]
@@ -18,6 +18,21 @@
 		},
 		"check-types": {
 			"dependsOn": ["^check-types"]
+		},
+		"test": {
+			"dependsOn": ["^test", "@repo/vitest-config#build"],
+			"outputs": ["coverage/**"]
+		},
+		"test:watch": {
+			"cache": false,
+			"persistent": true
+		},
+		"//#test:projects": {
+			"outputs": ["coverage/**"]
+		},
+		"//#test:projects:watch": {
+			"cache": false,
+			"persistent": true
 		},
 		"dev": {
 			"cache": false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import { sharedConfig } from "@repo/vitest-config";
+
+export default defineConfig({
+	...sharedConfig,
+	projects: [
+		{
+			name: "packages",
+			root: "./packages/*",
+			test: {
+				...sharedConfig.test,
+				// Project-specific configuration
+			},
+		},
+	],
+});


### PR DESCRIPTION
Implements Vitest testing setup with hybrid approach as requested in issue #2.

## Changes
- Add shared vitest-config package
- Set up root vitest config with projects
- Configure UI package with sample tests
- Add coverage merging with nyc
- Update turbo.json with test tasks
- Add test scripts to package.json

Resolves #2

Generated with [Claude Code](https://claude.ai/code)